### PR TITLE
Add chrony.removed state to uninstall package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,3 +18,7 @@ Installs the chrony package.
 ``chrony.config``
 -----------------
 This state manages the file ``chrony.conf`` under ``/etc`` (template found in "chrony/files"). The configuration is populated by values in "chrony/map.jinja", which are based on the package's default values (for RedHat, Debian and Arch family distributions), and are overridden by values of the same name in pillar.
+
+``chrony.removed``
+-----------------
+Stops the service and uninstalls the package.

--- a/chrony/removed.sls
+++ b/chrony/removed.sls
@@ -1,0 +1,10 @@
+{% from "chrony/map.jinja" import chrony with context %}
+
+chrony_removed:
+  service.dead:
+    - enable: False
+    - name: {{ chrony.service }}
+  pkg.removed:
+    - name: {{ chrony.package }}
+    - require:
+      - service: chrony_removed


### PR DESCRIPTION
When calling chrony.removed salt ensures the service is stopped
and the package has been removed.