### PR TITLE
Add osmapping,defaults for modular parms

### DIFF
--- a/chrony/defaults.yaml
+++ b/chrony/defaults.yaml
@@ -1,0 +1,27 @@
+# Default lookup dictionary
+
+chrony:
+  package: chrony
+  service: chronyd
+  config: /etc/chrony.conf
+  config_src: salt://chrony/files/chrony_config
+  ntpservers:  [ '0.us.pool.ntp.org',
+                 '1.us.pool.ntp.org',
+                 '2.us.pool.ntp.org',
+                 '3.us.pool.ntp.org'
+               ]
+  options: iburst
+  logdir: /var/log/chrony
+  keyfile: /etc/chrony.keys
+  driftfile: /var/lib/chrony/drift,
+  otherparams: [ 'rtcsync',
+                 'makestep 10 3',
+                 'stratumweight 0',
+                 'bindcmdaddress 127.0.0.1',
+                 'bindcmdaddress ::1',
+                 'commandkey 1',
+                 'generatecommandkey',
+                 'noclientlog',
+                 'logchange 0.5',
+                ]
+  allow:  [ '10/8', '192.168/16', '172.16/12' ]

--- a/chrony/map.jinja
+++ b/chrony/map.jinja
@@ -1,88 +1,20 @@
-{% set chrony = salt['grains.filter_by']({
-    'Debian': {
-      'package':     'chrony',
-      'service':     'chrony',
-      'config':       '/etc/chrony/chrony.conf',
-      'config_src':  'salt://chrony/files/chrony_config',
-      'ntpservers':  [
-                     '0.debian.pool.ntp.org', 
-                     '1.debian.pool.ntp.org',
-                     '2.debian.pool.ntp.org',
-                     '3.debian.pool.ntp.org'
-                     ],
-      'options':     'offline minpoll 8',
-      'allow':       [
-                     '10/8',
-                     '192.168/16',
-                     '172.16/12'
-                     ],
-      'logdir':      '/var/log/chrony',
-      'keyfile':     '/etc/chrony/chrony.keys',
-      'driftfile':   '/var/lib/chrony/chrony.drift',
-      'otherparams': [
-                     'log tracking measurements statistics',
-                     'maxupdateskew 100.0',
-                     'dumponexit',
-                     'dumpdir /var/lib/chrony',
-                     'commandkey 1',
-                     'local stratum 10',
-                     'rtconutc'
-                     ],
-    },
-    'RedHat': {
-      'package':     'chrony',
-      'service':     'chronyd',
-      'config':      '/etc/chrony.conf',
-      'config_src':  'salt://chrony/files/chrony_config',
-      'ntpservers':  [
-                     '0.centos.pool.ntp.org',
-                     '1.centos.pool.ntp.org',
-                     '2.centos.pool.ntp.org',
-                     '3.centos.pool.ntp.org'
-                      ],
-      'options':     'iburst',
-      'logdir':      '/var/log/chrony',
-      'keyfile':     '/etc/chrony.keys',
-      'driftfile':   '/var/lib/chrony/drift',
-      'otherparams': [
-                     'rtcsync',
-                     'makestep 10 3',
-                     'stratumweight 0',
-                     'bindcmdaddress 127.0.0.1',
-                     'bindcmdaddress ::1',
-                     'commandkey 1',
-                     'generatecommandkey',
-                     'noclientlog',
-                     'logchange 0.5',
-                     ],
-    },
-    'Arch': {
-      'package':     'chrony',
-      'service':     'chronyd',
-      'config':      '/etc/chrony.conf',
-      'config_src':  'salt://chrony/files/chrony_config',
-      'ntpservers':  [
-                     '0.arch.pool.ntp.org',
-                     '1.arch.pool.ntp.org',
-                     '2.arch.pool.ntp.org'
-                      ],
-      'options':     'iburst',
-      'logdir':      '/var/log/chrony',
-      'keyfile':     '/etc/chrony.keys',
-      'driftfile':   '/var/lib/chrony/drift',
-      'otherparams': [
-                     'rtconutc',
-                     'rtcsync',
-                     ],
-    }
-  },
-  grain='os_family',
-  merge=salt['pillar.get']('chrony:config'))
-%}
+{## start with defaults from defaults.yaml ##}
+{% import_yaml "chrony/defaults.yaml" as defaults %}
+{% import_yaml "chrony/osmap.yaml" as osmap %}
 
-{# Debian distros check /etc/default/rcS to determine UTC setting #}
-{% if grains['os_family'] == "Debian" %}
-  {% if salt['cmd.run']('grep UTC=no /etc/default/rcS') %}
-    {% do chrony['otherparams'].remove('rtconutc') %}
-  {% endif %}
-{% endif %}
+{% set chrony = salt['grains.filter_by'](
+    defaults,
+    merge=salt['grains.filter_by'](
+        osmap,
+        grain='os_family',
+        merge=salt['pillar.get']('chrony', {}),
+        ),
+    base='chrony'
+) %}
+
+-{# Debian distros check /etc/default/rcS to determine UTC setting #}
+-{% if grains['os_family'] == "Debian" %}
+-  {% if salt['cmd.run']('grep UTC=no /etc/default/rcS') %}
+-    {% do chrony['otherparams'].remove('rtconutc') %}
+-  {% endif %}
+-{% endif %}

--- a/chrony/osmap.yaml
+++ b/chrony/osmap.yaml
@@ -1,0 +1,52 @@
+# OS parameters overriding common defaults(.yaml)
+
+Debian:
+  service: chrony
+  config: /etc/chrony/chrony.conf
+  ntpservers: [ '0.debian.pool.ntp.org', 
+                '1.debian.pool.ntp.org',
+                '2.debian.pool.ntp.org',
+                '3.debian.pool.ntp.org', ]
+  options: offline minpoll 8
+  keyfile: /etc/chrony/chrony.keys
+  driftfile: /var/lib/chrony/chrony.drift
+  otherparams: [ 'log tracking measurements statistics',
+                 'maxupdateskew 100.0',
+                 'dumponexit',
+                 'dumpdir /var/lib/chrony',
+                 'commandkey 1',
+                 'local stratum 10',
+                 'rtconutc', ]
+
+RedHat:
+  ntpservers: [ '0.centos.pool.ntp.org',
+                '1.centos.pool.ntp.org',
+                '2.centos.pool.ntp.org',
+                '3.centos.pool.ntp.org', ]
+  otherparams: [ 'rtcsync',
+                 'makestep 10 3',
+                 'stratumweight 0',
+                 'bindcmdaddress 127.0.0.1',
+                 'bindcmdaddress ::1',
+                 'commandkey 1',
+                 'generatecommandkey',
+                 'noclientlog',
+                 'logchange 0.5', ]
+
+Arch:
+  ntpservers: [ '0.arch.pool.ntp.org',
+                 '1.arch.pool.ntp.org',
+                 '2.arch.pool.ntp.org' ]
+  otherparams: [ 'rtconutc',
+                 'rtcsync', ]
+
+Suse:
+  ntpservers: [ '0.arch.opensuse.ntp.org',
+                '1.arch.opensuse.ntp.org',
+                '2.arch.opensuse.ntp.org',
+                '3.opensuse.pool.ntp.org', ]
+  otherparams: [ 'rtcsync',
+                 'makestep 10 3',
+                 'maxdistance 6',
+                 'logchange 0.1', ]
+


### PR DESCRIPTION
This pull request enhances the formula by introducing the more modular design promoted by the community (see template-formula).  It allows for good defaults (see pillar.example) to be delegated to the for-purpose **defaults.yaml** artifact, for good Distribution family defaults to be relegated to osmap.yaml, and reduces an over-reliance on map.jinja and pillars for a working formula.

Changelog:
1. Introduce defaults.yaml & replicate defaults from pillar.example here.
2. Introduce osmap.yaml & move mapping from map.jinja here. Add Suse support.
3. Introduce simple map.jinja design promoted by community.

Fixes:
This PR seems to resolve #1.

Verified on CENT7, Suse, Ubuntu and Archlinux.
[chrony_centos.log](https://github.com/saltstack-formulas/chrony-formula/files/1373764/chrony_centos.log)
[chrony_centos2.log](https://github.com/saltstack-formulas/chrony-formula/files/1373765/chrony_centos2.log)
[chrony_suse_result.log](https://github.com/saltstack-formulas/chrony-formula/files/1373770/chrony_suse_result.log)
[chrony_ubuntu.log](https://github.com/saltstack-formulas/chrony-formula/files/1373771/chrony_ubuntu.log)


