### PR TITLE
Hide salt stdout [ERROR] if grep rc=1

### DIFF
--- a/chrony/map.jinja
+++ b/chrony/map.jinja
@@ -14,7 +14,7 @@
 
 -{# Debian distros check /etc/default/rcS to determine UTC setting #}
 -{% if grains['os_family'] == "Debian" %}
--  {% if salt['cmd.run']('grep UTC=no /etc/default/rcS') %}
+-  {% if salt['cmd.run']('grep UTC=no /etc/default/rcS', output_loglevel='quiet') %}
 -    {% do chrony['otherparams'].remove('rtconutc') %}
 -  {% endif %}
 -{% endif %}


### PR DESCRIPTION
This PR fixes annoyance where salt.cmd.run prints '[ERROR]' message three times to stdout.

`[ERROR    ] Command 'grep UTC=no /etc/default/rcS' failed with return code 1`

We just need to set logging to quiet. Tested on Ubuntu without issues.