### PR TITLE
fix default values

### DIFF
--- a/chrony/defaults.yaml
+++ b/chrony/defaults.yaml
@@ -17,13 +17,8 @@ chrony:
   driftfile: /var/lib/chrony/drift
   otherparams:
     - 'rtcsync'
-    - 'makestep 10 3'
-    - 'stratumweight 0'
+    - 'makestep 0.1 3'
+    - 'stratumweight 0.001'
     - 'bindcmdaddress 127.0.0.1'
     - 'bindcmdaddress ::1'
-    - 'noclientlog'
-    - 'logchange 0.5'
-  allow:
-    - '10/8'
-    - '192.168/16'
-    - '172.16/12'
+    - 'logchange 1'


### PR DESCRIPTION
This PR update the defaults for Chrony

* Remove `allow` default values
This is because by adding the allow option to `chrony.conf` this will make Chrony act as a NTP server, instead of a client.  This PR doesn't prevent the ability to set the options using Pillar, just prevents it from being set by `defaults.yaml`
* Update `makestep` default value to 0.1
* Update `stratumweight` to 0.001
* Update `logchange` to 1
* Remove `noclientlog`

These values were pulled from the Chrony configuration page [here](https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html)