### PR TITLE
fix: add pool option

### DIFF
--- a/chrony/files/default/chrony.conf.jinja
+++ b/chrony/files/default/chrony.conf.jinja
@@ -3,22 +3,30 @@
 # Your changes will be overwritten.
 ########################################################################
 
+{%- if chrony.ntpservers is defined %}
 {% for server in chrony.ntpservers -%}
 server {{ server }} {{ chrony.options }}
 {% endfor %}
+{%- endif %}
+
+{%- if chrony.pool is defined %}
+{% for pool in chrony.pool -%}
+pool {{ pool }} {{ chrony.options }}
+{% endfor %}
+{% endif %}
 
 keyfile {{ chrony.keyfile }}
 
 driftfile {{ chrony.driftfile }}
 
 {% if chrony.allow is defined %}
-{% for allowed in chrony.get('allow', []) -%}
+{% for allowed in chrony.get('allow', {}) -%}
 allow {{ allowed }}
 {% endfor %}
 {%- endif %}
 
 logdir {{ chrony.logdir }}
 
-{% for param in chrony.get('otherparams', []) -%}
+{% for param in chrony.get('otherparams', {}) -%}
 {{ param }}
 {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,11 @@ chrony:
     - '1.centos.pool.ntp.org'
     - '2.arch.pool.ntp.org'
     - '3.gentoo.pool.ntp.org'
+  pool:
+    - '0.debian.pool.ntp.org'
+    - '1.centos.pool.ntp.org'
+    - '2.arch.pool.ntp.org'
+    - '3.gentoo.pool.ntp.org'
   allow:
     - '10/8'
     - '192.168/16'


### PR DESCRIPTION
This adds the ability to use the `pool` option instead of `server`.

"The syntax of this directive is similar to that for the server directive, except that it is used to specify a pool of NTP servers rather than a single NTP server."

More information can be found [here](https://chrony.tuxfamily.org/doc/3.5/chrony.conf.html#pool)


Note: I am going to create another PR to remove default settings being applied for `ntpservers` but still allow the option to prevent breakage for now.  At some point we should switch from `ntpservers` to just `server` or `servers` to follow the configuration file syntax.

