### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/chrony/config/file.sls
+++ b/chrony/config/file.sls
@@ -13,7 +13,7 @@ include:
 chrony-config-file-file-managed:
   file.managed:
     - name: {{ chrony.config }}
-    - source: {{ files_switch(['chrony.conf', 'chrony.conf.jinja'],
+    - source: {{ files_switch(['chrony.conf.jinja'],
                               lookup='chrony-config-file-file-managed'
                  )
               }}

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 chrony:
   ntpservers:
     - '0.debian.pool.ntp.org'
@@ -18,25 +21,24 @@ chrony:
     - 'generatecommandkey'
     - 'noclientlog'
     - 'logchange 0.5'
-  # tofs:
-  #   # The files_switch key serves as a selector for alternative
-  #   # directories under the formula files directory. See TOFS pattern
-  #   # doc for more info.
-  #   # Note: Any value not evaluated by `config.get` will be used literally.
-  #   # This can be used to set custom paths, as many levels deep as required.
-  #   files_switch:
-  #     - any/path/can/be/used/here
-  #     - id
-  #     - osfinger
-  #     - os
-  #     - os_family
-  #   # All aspects of path/file resolution are customisable using the options below.
-  #   # This is unnecessary in most cases; there are sensible defaults.
-  #   path_prefix: template_alt
-  #   dirs:
-  #     files: files_alt
-  #     default: default_alt
-  #   source_files:
-  #     chrony-config-file-file-managed:
-  #       - 'chrony_alt.conf'
-  #       - 'chrony_alt.conf.jinja'
+  tofs:
+    # # The files_switch key serves as a selector for alternative
+    # # directories under the formula files directory. See TOFS pattern
+    # # doc for more info.
+    # # Note: Any value not evaluated by `config.get` will be used literally.
+    # # This can be used to set custom paths, as many levels deep as required.
+    # files_switch:
+    #   - any/path/can/be/used/here
+    #   - id
+    #   - osfinger
+    #   - os
+    #   - os_family
+    # # All aspects of path/file resolution are customisable using the options below.
+    # # This is unnecessary in most cases; there are sensible defaults.
+    # path_prefix: template_alt
+    # dirs:
+    #   files: files_alt
+    #   default: default_alt
+    source_files:
+      chrony-config-file-file-managed:
+        - 'chrony.conf'

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: chrony formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
chrony-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
pillar.example
  1:1       warning  missing document start "---"  (document-start)
  21:3      warning  comment not indented like content  (comments-indentation)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.